### PR TITLE
Paypal payment method and some warning fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,17 @@ Payment.create_payment(%Paypal.Payment{intent: "authorize", payer: %{"funding_in
 ```
 or if using Paypal as the payment method:
 ```elixir
-Payment.create_payment(%Paypal.Payment{intent: "authorize", payer: %{"payment_method" => "paypal"}, transactions: [%{"amount" => %{"currency" => "USD", "details" => %{"shipping" => "0.03", "subtotal" => "7.41", "tax" => "0.03"}, "total" => "7.47"}, "description" => "This is the payment transaction description."}]})
-
+# create payment
+payment = Payment.create_payment(%Paypal.Payment{
+  intent: "sale",
+  payer: %{"payment_method" => "paypal"},
+  transactions: [%{"amount" => %{"currency" => "USD", "details" => %{"shipping" => "0.03", "subtotal" => "7.41", "tax" => "0.03"}, "total" => "7.47"}, "description" => "This is the payment transaction description."}],
+  redirect_urls: %{"return_url" => "http://YOUR_RETURN_URL", "cancel_url" => "http://YOUR_CANCEL_URL"}
+})
+approval_url = Enum.find(payment["links"], fn (x) -> x["rel"] == "approval_url" and x["method"] == "REDIRECT" end)
+# redirect user to approval_url["href"]
+# after user has approved the payment, we can execute it on return url call.
+Payment.execute_payment(%Paypal.Payment{id: "PAYMENT_ID_FROM_RETURN_CALL", payer: %{payer_id: "PAYER_ID_FROM_RETURN_CALL"}})
 ```
 
 then add the `pay` to your `config/config.exs`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Creating a Payment (you must use the PaypalPayment struct):
 Payment.create_payment(%Paypal.Payment{intent: "authorize", payer: %{"funding_instruments" => [%{"credit_card" => %{"billing_address" => %{"city" => "Saratoga", "country_code" => "US", "line1" => "111 First Street", "postal_code" => "95070", "state" => "CA"}, "cvv2" => "874", "expire_month" => 11, "expire_year" => 2018, "first_name" => "Betsy", "last_name" => "Buyer", "number" => "4417119669820331", "type" => "visa"}}], "payment_method" => "credit_card"}, transactions: [%{"amount" => %{"currency" => "USD", "details" => %{"shipping" => "0.03", "subtotal" => "7.41", "tax" => "0.03"}, "total" => "7.47"}, "description" => "This is the payment transaction description."}]})
 
 ```
+or if using Paypal as the payment method:
+```elixir
+Payment.create_payment(%Paypal.Payment{intent: "authorize", payer: %{"payment_method" => "paypal"}, transactions: [%{"amount" => %{"currency" => "USD", "details" => %{"shipping" => "0.03", "subtotal" => "7.41", "tax" => "0.03"}, "total" => "7.47"}, "description" => "This is the payment transaction description."}]})
+
+```
 
 then add the `pay` to your `config/config.exs`
 ```elixir
@@ -22,9 +27,10 @@ config :pay, type: :paypal
 ```
 And also your key from paypal:
 ```elixir
-config :paypal, client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
-              secret: "EClusMEUk8e9ihI7ZdVLF5cZ6y0SFdVsY9183IvxFyZp",
-              env: :prod
+config :pay, :paypal,
+  client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
+  secret: "EClusMEUk8e9ihI7ZdVLF5cZ6y0SFdVsY9183IvxFyZp",
+  env: :prod
 ```
 
 In your mix file:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 #config :pay, type: :paypal
-config :paypal, client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
-              secret: "EClusMEUk8e9ihI7ZdVLF5cZ6y0SFdVsY9183IvxFyZp",
-              env: :sandbox
+config :pay, :paypal,
+  client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
+  secret: "EClusMEUk8e9ihI7ZdVLF5cZ6y0SFdVsY9183IvxFyZp",
+  env: :sandbox

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,6 @@
 use Mix.Config
 
-config :paypal, client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
-              secret: "8097ba8918d04eefb95b539a2fce1f56",
-              env: :sandbox
+config :pay, :paypal,
+  client_id: "EOJ2S-Z6OoN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp",
+  secret: "8097ba8918d04eefb95b539a2fce1f56",
+  env: :sandbox

--- a/lib/paypal/config.ex
+++ b/lib/paypal/config.ex
@@ -3,12 +3,12 @@ defmodule Paypal.Config do
   @sand_box_url "https://api.sandbox.paypal.com/v1"
 
   def url do
-    case Application.get_env(:paypal, :env) do 
+    case Application.get_env(:pay, :paypal)[:env] do
       :sandbox -> @sand_box_url
       _ -> @api_url
     end
   end
-   
+
 
   def parse_response(response) do
     case response do

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -9,8 +9,8 @@ defmodule Paypal.Payment do
   update: used at the Payment.update protocol.
   """
   @derive [Poison.Encoder]
-  defstruct intent: nil, payer: nil, transactions: nil, id: nil, op: nil, update: nil
-  @type p :: %Paypal.Payment{intent: String.t, payer: any, transactions: list(any), 
+  defstruct intent: nil, payer: nil, transactions: nil, id: nil, op: nil, update: nil, redirect_urls: nil
+  @type p :: %Paypal.Payment{intent: String.t, payer: any, transactions: list(any), redirect_urls: any,
                             id: integer, op: String.t, update: list(any)}
 
 end

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -90,7 +90,7 @@ defimpl Payment, for: Paypal.Payment do
 
   defp do_execute_payment(payment) do
     HTTPoison.post(Paypal.Config.url <> "/payments/payment/#{payment.id}/execute", 
-      Poison.econde!(%{payer_id: payment.payer.id, transactions: payment.transactions}),  
+      Poison.encode!(%{payer_id: payment.payer.id}),  
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
   end
@@ -108,7 +108,7 @@ defimpl Payment, for: Paypal.Payment do
   defp do_execute_payment(payment) do
     refund = Enum.first(payment.transactions)
     HTTPoison.post(Paypal.Config.url <> "/payments/sale/#{payment.id}/refund",  
-      Poison.econde!(%{total: refund.total, currency: refund.currency}),  
+      Poison.encode!(%{total: refund.total, currency: refund.currency}),  
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
 

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -105,13 +105,13 @@ defimpl Payment, for: Paypal.Payment do
   def refund(payment) do
   end
 
-  defp do_execute_payment(payment) do
-    refund = Enum.first(payment.transactions)
-    HTTPoison.post(Paypal.Config.url <> "/payments/sale/#{payment.id}/refund",
-      Poison.encode!(%{total: refund.total, currency: refund.currency}),
-      Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
-    |> Paypal.Config.parse_response
+  # defp do_execute_payment(payment) do
+  #   refund = Enum.first(payment.transactions)
+  #   HTTPoison.post(Paypal.Config.url <> "/payments/sale/#{payment.id}/refund",
+  #     Poison.encode!(%{total: refund.total, currency: refund.currency}),
+  #     Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
+  #   |> Paypal.Config.parse_response
 
-  end
+  # end
 
 end

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -102,7 +102,7 @@ defimpl Payment, for: Paypal.Payment do
   payment muast be:
   $Paypal.Payment{id: PAYMENT_ID, transactions: [%{total: TOTAL, currency: CURRENCY}]}
   """
-  def refund(payment) do
+  def refund(_payment) do
   end
 
   # defp do_execute_payment(payment) do

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -23,16 +23,16 @@ defimpl Payment, for: Paypal.Payment do
 
     Example of payment struct: %Paypal.Payment{"intent" => "sale", "payer" => %{"funding_instruments" => [%{"credit_card" => %{"billing_address" => %{"city" => "Saratoga", "country_code" => "US", "line1" => "111 First Street", "postal_code" => "95070", "state" => "CA"}, "cvv2" => "874", "expire_month" => 11, "expire_year" => 2018, "first_name" => "Betsy", "last_name" => "Buyer", "number" => "4417119669820331", "type" => "visa"}}], "payment_method" => "credit_card"}, "transactions" => [%{"amount" => %{"currency" => "USD", "details" => %{"shipping" => "0.03", "subtotal" => "7.41", "tax" => "0.03"}, "total" => "7.47"}, "description" => "This is the payment transaction description."}]}
     The information about the value of the keys are in https://developer.paypal.com/webapps/developer/docs/api/#create-a-payment
-    
+
     Returns a Task.
   """
   def create_payment(payment) do
     Task.async(fn -> do_create_payment(payment) end)
   end
 
-  defp do_create_payment(payment) do 
+  defp do_create_payment(payment) do
     string_payment = format_create_payment_request  Poison.encode!(payment)
-    HTTPoison.post(Paypal.Config.url <> "/payments/payment", string_payment, 
+    HTTPoison.post(Paypal.Config.url <> "/payments/payment", string_payment,
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
   end
@@ -47,13 +47,13 @@ defimpl Payment, for: Paypal.Payment do
   It receives a Paypal.Payment struct with id.
   """
   def get_status(payment) do
-    HTTPoison.get(Paypal.Config.url <> "/payments/payment/" <> payment.id, Paypal.Authentication.headers, 
+    HTTPoison.get(Paypal.Config.url <> "/payments/payment/" <> payment.id, Paypal.Authentication.headers,
       timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
   end
 
   @doc """
-  Function to update payment fields. You have to pass in the update key a list with a HashDict with following keys: 
+  Function to update payment fields. You have to pass in the update key a list with a HashDict with following keys:
   op  string  Patch operation to perform. Allowed values: add and replace.
   path  string  String containing a JSON-Pointer value that references a location within the target document (the target location) where the operation is performed.
   value object  New value to apply based on the operation. Allowed objects are amount object or shipping_address object.
@@ -65,7 +65,7 @@ defimpl Payment, for: Paypal.Payment do
       Task.async fn -> do_update_payment(payment) end
   end
   def do_update_payment(payment) do
-    HTTPoison.patch(Paypal.Config.url <>  "/payments/payment/" <> payment.id, Poison.encode!(payment.update), 
+    HTTPoison.patch(Paypal.Config.url <>  "/payments/payment/" <> payment.id, Poison.encode!(payment.update),
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
       |> Paypal.Config.parse_response
   end
@@ -79,36 +79,36 @@ defimpl Payment, for: Paypal.Payment do
   end
 
   @doc """
-  Use this call to execute (complete) a PayPal payment that has been approved by the payer. 
+  Use this call to execute (complete) a PayPal payment that has been approved by the payer.
   You can optionally update transaction information when executing the payment by passing in one or more transactions.
   You have to set at least: %Paypal.Payment{id: PAYMENT_ID, payer: %{id: PAYER_ID}}
 
   """
-  def execute_payment(payment) do 
+  def execute_payment(payment) do
     Task.async fn -> do_execute_payment(payment) end
   end
 
   defp do_execute_payment(payment) do
-    HTTPoison.post(Paypal.Config.url <> "/payments/payment/#{payment.id}/execute", 
-      Poison.encode!(%{payer_id: payment.payer.id}),  
+    HTTPoison.post(Paypal.Config.url <> "/payments/payment/#{payment.id}/execute",
+      Poison.encode!(%{payer_id: payment.payer.id}),
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
   end
 
   @doc """
-  Use this call to refund a completed payment. 
+  Use this call to refund a completed payment.
   Provide the sale_id in the URI and an empty JSON payload for a full refund.
   For partial refunds, you can include an amount.
   payment muast be:
   $Paypal.Payment{id: PAYMENT_ID, transactions: [%{total: TOTAL, currency: CURRENCY}]}
   """
-  def refund(payment) do 
+  def refund(payment) do
   end
 
   defp do_execute_payment(payment) do
     refund = Enum.first(payment.transactions)
-    HTTPoison.post(Paypal.Config.url <> "/payments/sale/#{payment.id}/refund",  
-      Poison.encode!(%{total: refund.total, currency: refund.currency}),  
+    HTTPoison.post(Paypal.Config.url <> "/payments/sale/#{payment.id}/refund",
+      Poison.encode!(%{total: refund.total, currency: refund.currency}),
       Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
     |> Paypal.Config.parse_response
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,9 @@ defmodule Pay.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:maru, "~> 0.7"}, {:httpoison, "~> 0.6"},{:timex, "~> 0.19.5"}, 
+    [{:maru, "~> 0.7"},
+    {:httpoison, "~> 0.8"},
+    {:timex, "~> 2.1.5"},
     {:mock, "~> 0.1.1", only: :test},
     {:dogma, "~> 0.0", only: :dev}]
   end


### PR DESCRIPTION
The current implementation only support direct credit card payment creation. I modified payment module to support Paypal payment_method which later on I found some issues on the execute_payment.

The second one is to fix warnings when using on phoenix framework. The warning is related to :paypal configuration object, so I added some changes to make configuration load from :pay, :paypal.
