### PR TITLE
Proper check of the get_token response

### DIFF
--- a/lib/payment.ex
+++ b/lib/payment.ex
@@ -4,5 +4,6 @@ defprotocol Payment do
   def update_payment(payment)
   def get_payments(payment)
   def execute_payment(payment)
+  def get_details(payment)
   def refund(payment)
 end

--- a/lib/paypal/agreement.ex
+++ b/lib/paypal/agreement.ex
@@ -10,9 +10,9 @@ defimpl Agreement, for: [Paypal.Agreement, BitString] do
 
   defp do_create(agreement) do
     string_agreement = Poison.encode!(agreement)
-    HTTPoison.post(Paypal.Config.url <> "/payments/billing-agreements", string_agreement,
-      Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
-    |> Paypal.Config.parse_response
+    with {:ok, headers } <- Paypal.Authentication.headers(),
+      do: HTTPoison.post(Paypal.Config.url <> "/payments/billing-agreements", string_agreement, headers, timeout: :infinity, recv_timeout: :infinity)
+          |> Paypal.Config.parse_response
   end
 
   def execute(token) do
@@ -20,8 +20,8 @@ defimpl Agreement, for: [Paypal.Agreement, BitString] do
   end
 
   defp do_execute(token) do
-    HTTPoison.post(Paypal.Config.url <> "/payments/billing-agreements/#{token}/agreement-execute",
-      "{}", Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
-    |> Paypal.Config.parse_response
+    with {:ok, headers} <- Paypal.Authentication.headers(),
+      do: HTTPoison.post(Paypal.Config.url <> "/payments/billing-agreements/#{token}/agreement-execute", "{}", headers, timeout: :infinity, recv_timeout: :infinity)
+        |> Paypal.Config.parse_response
   end
 end

--- a/lib/paypal/app.ex
+++ b/lib/paypal/app.ex
@@ -1,10 +1,10 @@
 defmodule Paypal.App do
   import Supervisor.Spec 
 
-  def start(type,args) do
+  def start(type, args) do
     children = [
       worker(Paypal.Authentication, [[type,args], [name: __MODULE__]])
     ]
-    {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+    {:ok, _pid} = Supervisor.start_link(children, strategy: :one_for_one)
   end
 end

--- a/lib/paypal/authentication.ex
+++ b/lib/paypal/authentication.ex
@@ -12,11 +12,15 @@ defmodule Paypal.Authentication do
   @doc """
   Function that returns a valid token. If the token has expired, it makes a call to paypal.
   """
-  def token do
-    if is_expired do
-      request_token
+  def get_token do
+    if is_expired() do
+      case request_token() do
+        :ok -> {:ok, Agent.get(:token, &(&1))}
+        _ -> {:error, "Could't request token"}
+      end
+    else
+      {:ok, Agent.get(:token, &(&1))}
     end
-    Agent.get(:token, &(&1))
   end
 
   defp is_expired do
@@ -27,11 +31,9 @@ defmodule Paypal.Authentication do
   defp get_env(key), do: Application.get_env(:pay, :paypal)[key]
 
   defp request_token do
-    hackney = [basic_auth: {get_env(:client_id), get_env(:secret)}]
-    HTTPoison.post(Paypal.Config.url <> "/oauth2/token", "grant_type=client_credentials", basic_headers, [ hackney: hackney ])
-    |> Paypal.Config.parse_response
-    |> parse_token
-    |> update_token
+    hackney = [basic_auth: { get_env(:client_id), get_env(:secret) }]
+    with {:ok, response } <- HTTPoison.post(Paypal.Config.url <> "/oauth2/token", "grant_type=client_credentials", basic_headers(), [ hackney: hackney ]) |> Paypal.Config.parse_response(),
+      do: parse_token(response) |> update_token()
   end
 
   defp update_token({:ok, access_token, expires_in}) do
@@ -39,20 +41,29 @@ defmodule Paypal.Authentication do
     Agent.update(:token, fn _ -> %{token: access_token, expires_in: now + expires_in }  end)
   end
 
-  defp parse_token ({:ok, response}) do
+  defp parse_token (response) do
     {:ok, response["access_token"], response["expires_in"]}
   end
 
   @doc """
   Auth Headers needed to make a request to paypal.
   """
-  def headers, do: Enum.concat(request_headers, authorization_header)
+  def headers do
+    case authorization_header() do
+      {:ok, auth_header} -> {:ok, Enum.concat(request_headers(), auth_header)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   defp authorization_header do
-    %{token: access_token, expires_in: _expires_in} = token
-    [{"Authorization", "Bearer " <>  access_token}]
+    case get_token() do
+      {:ok, %{token: access_token }} ->
+        {:ok, [{"Authorization", "Bearer " <>  access_token}]}
+      {:error, reason} ->
+        {:error, reason}
+    end    
   end
-  defp request_headers, do: [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
-  defp basic_headers, do: [{"Accept", "application/json"}, {"Content-Type", "application/x-www-form-urlencoded"}]
+  defp request_headers(), do: [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
+  defp basic_headers(), do: [{"Accept", "application/json"}, {"Content-Type", "application/x-www-form-urlencoded"}]
 
 end

--- a/lib/paypal/config.ex
+++ b/lib/paypal/config.ex
@@ -9,7 +9,6 @@ defmodule Paypal.Config do
     end
   end
 
-
   def parse_response(response) do
     case response do
       {:ok, %HTTPoison.Response{status_code: 401,  body: body, headers: _headers}} ->
@@ -20,6 +19,5 @@ defmodule Paypal.Config do
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:nok, reason}
     end
-
   end
 end

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -104,6 +104,20 @@ defimpl Payment, for: Paypal.Payment do
   end
 
   @doc """
+  Use this to get sale information
+  https://developer.paypal.com/docs/api/payments/#sale_get
+  """
+  def get_sale_details(payment) do
+    Task.async fn -> do_get_sale_details(payment) end
+  end
+
+  defp do_get_sale_details(payment) do
+    with {:ok, headers} <- Paypal.Authentication.headers(),
+      do: HTTPoison.get(Paypal.Config.url <> "/payments/sale/#{payment.id}", headers, timeout: :infinity, recv_timeout: :infinity)
+        |> Paypal.Config.parse_response
+  end
+
+  @doc """
   Use this call to refund a completed payment.
   Provide the sale_id in the URI and an empty JSON payload for a full refund.
   For partial refunds, you can include an amount.

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -107,13 +107,18 @@ defimpl Payment, for: Paypal.Payment do
   Use this to get sale information
   https://developer.paypal.com/docs/api/payments/#sale_get
   """
-  def get_sale_details(payment_id) do
-    Task.async fn -> do_get_sale_details(payment_id) end
+  def get_details(payment) do
+    Task.async fn -> do_get_details(payment) end
   end
 
-  defp do_get_sale_details(payment_id) do
+  defp do_get_details(payment) do
+    url = case payment.intent do
+      "sale" -> Paypal.Config.url <> "/payments/sale/#{payment.id}"
+      _ -> raise "only sale is supported"
+    end
+
     with {:ok, headers} <- Paypal.Authentication.headers(),
-      do: HTTPoison.get(Paypal.Config.url <> "/payments/sale/#{payment_id}", headers, timeout: :infinity, recv_timeout: :infinity)
+      do: HTTPoison.get(url, headers, timeout: :infinity, recv_timeout: :infinity)
         |> Paypal.Config.parse_response
   end
 

--- a/lib/paypal/payment.ex
+++ b/lib/paypal/payment.ex
@@ -107,13 +107,13 @@ defimpl Payment, for: Paypal.Payment do
   Use this to get sale information
   https://developer.paypal.com/docs/api/payments/#sale_get
   """
-  def get_sale_details(payment) do
-    Task.async fn -> do_get_sale_details(payment) end
+  def get_sale_details(payment_id) do
+    Task.async fn -> do_get_sale_details(payment_id) end
   end
 
-  defp do_get_sale_details(payment) do
+  defp do_get_sale_details(payment_id) do
     with {:ok, headers} <- Paypal.Authentication.headers(),
-      do: HTTPoison.get(Paypal.Config.url <> "/payments/sale/#{payment.id}", headers, timeout: :infinity, recv_timeout: :infinity)
+      do: HTTPoison.get(Paypal.Config.url <> "/payments/sale/#{payment_id}", headers, timeout: :infinity, recv_timeout: :infinity)
         |> Paypal.Config.parse_response
   end
 

--- a/lib/paypal/plan.ex
+++ b/lib/paypal/plan.ex
@@ -11,9 +11,9 @@ defimpl Plan, for: Paypal.Plan do
 
   defp do_create(plan) do
     string_plan = Poison.encode!(plan)
-    HTTPoison.post(Paypal.Config.url <> "/payments/billing-plans", string_plan,
-      Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
-    |> parse_response()
+    with {:ok, headers} <- Paypal.Authentication.headers(),
+      do: HTTPoison.post(Paypal.Config.url <> "/payments/billing-plans", string_plan, headers, timeout: :infinity, recv_timeout: :infinity)
+        |> parse_response()
   end
 
   def update(plan) do
@@ -21,10 +21,9 @@ defimpl Plan, for: Paypal.Plan do
   end
 
   defp do_update(plan) do
-    IO.inspect Paypal.Authentication.headers
-    HTTPoison.patch(Paypal.Config.url <> "/payments/billing-plans/#{plan.id}",
-      Poison.encode!([%{path: "/", value: %{"state" => "ACTIVE"}, op: "replace"}]),
-      Paypal.Authentication.headers, timeout: :infinity, recv_timeout: :infinity)
+    with {:ok, headers} <- Paypal.Authentication.headers(),
+      do: HTTPoison.patch(Paypal.Config.url <> "/payments/billing-plans/#{plan.id}", Poison.encode!([%{path: "/", value: %{"state" => "ACTIVE"}, op: "replace"}]),
+        headers, timeout: :infinity, recv_timeout: :infinity)
   end
 
   defp parse_response(response) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Pay.Mixfile do
 
   def project do
     [app: :pay,
-     version: "0.1.3",
+     version: "0.1.4",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Pay.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/test/paypal/authentication_test.exs
+++ b/test/paypal/authentication_test.exs
@@ -10,10 +10,13 @@ defmodule Paypal.AuthenticationTest do
         "expires_in": 28800
       }), headers: []}} end] do
       Paypal.App.start([],[])
-      assert %{token: token, expires_in: _} = Paypal.Authentication.token
+      assert {:ok, %{token: token, expires_in: _}} = Paypal.Authentication.get_token()
 
-      assert [{"Accept", "application/json"}, {"Content-Type", "application/json"},
-      {"Authorization", "Bearer " <> token}] == Paypal.Authentication.headers
+      assert {:ok, [
+        {"Accept", "application/json"},
+        {"Content-Type", "application/json"},
+        {"Authorization", "Bearer " <> token}
+      ]} == Paypal.Authentication.headers()
     end
   end
 end


### PR DESCRIPTION
Basically it adds some checks when you make a request where you need the headers.

```

    with {:ok, headers} <- Paypal.Authentication.headers(),
      do: HTTPoison.post(Paypal.Config.url <> "/payments/payment", string_payment, headers, timeout: :infinity, recv_timeout: :infinity)
        |> Paypal.Config.parse_response
```

Not sure, if that checks make sense, because the *let it fail* slogan?